### PR TITLE
Fix docs typo and remove whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@
 - sh (Python package)
 - click (Python package)
 - pathlib (Python package)
-- lighthouse (Node package) 
+- lighthouse (Node package)
 - shutil (Python packaage)
   *Lighthouse requires Node 6 or later.*
 - Google Chrome
 - Chrome Canary (Only needed for headless)
 
-**Installation:**  
-- Use `git clone` or download the project as a zip from this Github page. There are two file main files inside:  
-	- *setup.py*: used to install the three Python dependencies  
-	- *pointLoma.py*: the main script file, executes lighthouse and exports  results  
-- Install **lighthouse** using the following command:  
+**Installation:**
+- Use `git clone` or download the project as a zip from this Github page. There are two file main files inside:
+	- *setup.py*: used to install the three Python dependencies
+	- *pointLoma.py*: the main script file, executes lighthouse and exports  results
+- Install **lighthouse** using the following command:
 ```
     npm install -g lighthouse
     # or use yarn:
     yarn global add lighthouse
-```  
-   *Note:* lighthouse requires Node 6 or later. Install the current [Long-Term Support](https://github.com/nodejs/LTS) version of [Node](https://nodejs.org/).  
+```
+   *Note:* lighthouse requires Node 6 or later. Install the current [Long-Term Support](https://github.com/nodejs/LTS) version of [Node](https://nodejs.org/).
 - Google Chrome
 	Link: https://www.google.com/chrome/browser/desktop/index.html
 - Chrome Canary - Needed for only the headless mode, which still needs to be implemented for the python script.
@@ -41,7 +41,7 @@
 ```
     python setup.py install
 ```
-*Note:* Use *virutalenv* if you would like to test in a clean environment. It was used in testing and building of this script.
+*Note:* Use *virtualenv* if you would like to test in a clean environment. It was used in testing and building of this script.
 
 ## Usage
 Usage: `pointLoma [OPTIONS] LINK`
@@ -52,7 +52,7 @@ Options:
 
     --count=INTEGER  Number of tests to run. Default is 1.
 	--output-file=TEXT  Name of csv file w/o extension. Default is "output".
-	--help           Show this message and exit. 
+	--help           Show this message and exit.
 
 Examples:
 To specify the number of tests to run:
@@ -64,9 +64,9 @@ To specity the number of tests to run and the name csv file
 pointLoma --count=3 --output-file=learningEquality https://kolibridemo.learningequality.org
 ```
 ## Output
-Each test will output to a json file, *resultsN.report.json*, where *N*, is the test number. 
+Each test will output to a json file, *resultsN.report.json*, where *N*, is the test number.
 Unless specified, a csv file named 'output.csv' will contain the timestamp, the performance metrics, and the version we are testing.
-All files will be in the directory where the script was run. 
+All files will be in the directory where the script was run.
 
 ## Coming Soon
 - Testing multiple links automatically without using command line argument by using dictionary


### PR DESCRIPTION
Fix docs `virtualenv` typo and remove unnecessary whitespace.