### PR TITLE
Add dist and build directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ shtest.py
 venv/
 venvsh/
 yarn.lock
+dist/
+build/


### PR DESCRIPTION
If you choose to run setup.py install in the same directory where the
code is, build and dist outputs should be gitignored.